### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Usermover/Form/UserMover.php
+++ b/CRM/Usermover/Form/UserMover.php
@@ -92,7 +92,7 @@ class CRM_Usermover_Form_UserMover extends CRM_Core_Form {
     try {
       $results = civicrm_api3($entity, $action, $params);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       CRM_Core_Error::debug_log_message(ts('API Error %1', array(
         'domain' => 'com.aghstrategies.usermover',

--- a/api/v3/UserMover/Get.php
+++ b/api/v3/UserMover/Get.php
@@ -46,7 +46,7 @@ function _civicrm_api3_user_mover_Get_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_user_mover_Get($params) {
   $config = CRM_Core_Config::singleton();


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.